### PR TITLE
Clean up deprecation warnings and `Require Import`s

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -17,27 +17,17 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'mathcomp/mathcomp:1.12.0-coq-8.11'
           - 'mathcomp/mathcomp:1.12.0-coq-8.12'
           - 'mathcomp/mathcomp:1.12.0-coq-8.13'
           - 'mathcomp/mathcomp:1.12.0-coq-8.14'
-          - 'mathcomp/mathcomp:1.13.0-coq-8.11'
           - 'mathcomp/mathcomp:1.13.0-coq-8.12'
           - 'mathcomp/mathcomp:1.13.0-coq-8.13'
           - 'mathcomp/mathcomp:1.13.0-coq-8.14'
           - 'mathcomp/mathcomp:1.13.0-coq-8.15'
-          - 'mathcomp/mathcomp:1.14.0-coq-8.11'
           - 'mathcomp/mathcomp:1.14.0-coq-8.12'
           - 'mathcomp/mathcomp:1.14.0-coq-8.13'
           - 'mathcomp/mathcomp:1.14.0-coq-8.14'
           - 'mathcomp/mathcomp:1.14.0-coq-8.15'
-          - 'mathcomp/mathcomp:1.14.0-coq-dev'
-          - 'mathcomp/mathcomp-dev:coq-8.11'
-          - 'mathcomp/mathcomp-dev:coq-8.12'
-          - 'mathcomp/mathcomp-dev:coq-8.13'
-          - 'mathcomp/mathcomp-dev:coq-8.14'
-          - 'mathcomp/mathcomp-dev:coq-8.15'
-          - 'mathcomp/mathcomp-dev:coq-dev'
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ remains the sole trusted code base.
 - Coq-community maintainer(s):
   - Assia Mahboubi ([**@amahboubi**](https://github.com/amahboubi))
 - License: [CeCILL-C](LICENSE)
-- Compatible Coq versions: 8.11 or later
+- Compatible Coq versions: 8.12 or later
 - Additional dependencies:
   - [MathComp ssreflect 1.12 or later](https://math-comp.github.io)
   - [MathComp algebra](https://math-comp.github.io)

--- a/_CoqProject
+++ b/_CoqProject
@@ -2,6 +2,11 @@
 -R include mathcomp.apery
 -arg -w -arg -notation-overridden
 -arg -w -arg -ambiguous-paths
+-arg -w -arg +local-declaration
+-arg -w -arg +implicit-core-hint-db
+-arg -w -arg +deprecated-hint-without-locality
+-arg -w -arg +deprecated-hint-rewrite-without-locality
+-arg -w -arg +deprecated-instance-without-locality
 theories/a_props.v
 theories/annotated_recs_b.v
 theories/annotated_recs_c.v

--- a/include/ops_header.v
+++ b/include/ops_header.v
@@ -1,12 +1,6 @@
-Require Import ZArith.
-
+Require Import BinInt.
 From mathcomp Require Import all_ssreflect all_algebra.
-
-Require Import field_tactics.
-Require Import bigopz.
-Require Import lia_tactics conj.
-Require Import shift.
-
+Require Import field_tactics lia_tactics conj bigopz shift.
 Require punk.
 
 Set Implicit Arguments.

--- a/meta.yml
+++ b/meta.yml
@@ -46,19 +46,15 @@ license:
   identifier: CECILL-C
 
 supported_coq_versions:
-  text: 8.11 or later
+  text: 8.12 or later
   opam: '{(>= "8.11" & < "8.16~") | (= "dev")}'
 
 tested_coq_opam_versions:
-- version: '1.12.0-coq-8.11'
-  repo: 'mathcomp/mathcomp'
 - version: '1.12.0-coq-8.12'
   repo: 'mathcomp/mathcomp'
 - version: '1.12.0-coq-8.13'
   repo: 'mathcomp/mathcomp'
 - version: '1.12.0-coq-8.14'
-  repo: 'mathcomp/mathcomp'
-- version: '1.13.0-coq-8.11'
   repo: 'mathcomp/mathcomp'
 - version: '1.13.0-coq-8.12'
   repo: 'mathcomp/mathcomp'
@@ -68,8 +64,6 @@ tested_coq_opam_versions:
   repo: 'mathcomp/mathcomp'
 - version: '1.13.0-coq-8.15'
   repo: 'mathcomp/mathcomp'
-- version: '1.14.0-coq-8.11'
-  repo: 'mathcomp/mathcomp'
 - version: '1.14.0-coq-8.12'
   repo: 'mathcomp/mathcomp'
 - version: '1.14.0-coq-8.13'
@@ -78,20 +72,6 @@ tested_coq_opam_versions:
   repo: 'mathcomp/mathcomp'
 - version: '1.14.0-coq-8.15'
   repo: 'mathcomp/mathcomp'
-- version: '1.14.0-coq-dev'
-  repo: 'mathcomp/mathcomp'
-- version: 'coq-8.11'
-  repo: 'mathcomp/mathcomp-dev'
-- version: 'coq-8.12'
-  repo: 'mathcomp/mathcomp-dev'
-- version: 'coq-8.13'
-  repo: 'mathcomp/mathcomp-dev'
-- version: 'coq-8.14'
-  repo: 'mathcomp/mathcomp-dev'
-- version: 'coq-8.15'
-  repo: 'mathcomp/mathcomp-dev'
-- version: 'coq-dev'
-  repo: 'mathcomp/mathcomp-dev'
 
 dependencies:
 - opam:

--- a/theories/a_props.v
+++ b/theories/a_props.v
@@ -7,16 +7,10 @@ From CoqEAL Require Import hrel param refinements.
 From CoqEAL Require Import pos binnat binint rational.
 Import Refinements (* AlgOp *).
 
-Require Import binomialz bigopz.
 Require Import field_tactics lia_tactics shift.
-Require Import seq_defs.
-
-Require Import c_props.
-Require Import algo_closures.
+Require Import binomialz bigopz rho_computations.
 Require annotated_recs_c.
-
-Require Import rho_computations.
-Require Import initial_conds.
+Require Import seq_defs c_props initial_conds algo_closures.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -215,7 +209,7 @@ exact/hposM/exprn_ge0.
 Qed.
 
 (* delta is the discriminant *)
-Let delta (x : rat) := (alpha x) ^+ 2 - rat_of_positive 4 * (beta x).
+Local Definition delta (x : rat) := alpha x ^+ 2 - rat_of_positive 4 * beta x.
 
 Fact lt_0_delta (x : rat) : 0 <= x -> 0 < delta x.
 Proof.
@@ -271,7 +265,7 @@ Proof. by []. Qed.
 (*FIXME : Why a /= after goal_to_lia? *)
 Lemma rho_rec (i : int) : Posz 2 <= i -> rho (i + 1) = h i%:Q (rho i).
 Proof.
-move=> le2i. rewrite hE.
+move=> le2i; rewrite hE.
 have rhoi_neq0 : rho i != 0 by apply/lt0r_neq0/lt_0_rho/le_trans/le2i.
 have ai_neq0 : a i != 0 by apply/a_neq0/le_trans/le2i.
 rewrite -[alpha i%:Q](mulfK rhoi_neq0) -mulrBl; apply: canRL (mulfK _) _ => //.

--- a/theories/algo_closures.v
+++ b/theories/algo_closures.v
@@ -1,15 +1,10 @@
 (* In this file, we now propagate the theories in the ops_for_x files to
    prove results on our concrete sequences defined in seq_defs.v. *)
 
-Require Import ZArith.
-
 From mathcomp Require Import all_ssreflect all_algebra.
-Require Import binomialz.
-Require Import field_tactics lia_tactics shift.
-Require Import seq_defs.
-
-Require ops_for_a ops_for_b ops_for_s ops_for_u ops_for_v.
+Require Import field_tactics lia_tactics shift binomialz seq_defs.
 Require annotated_recs_c annotated_recs_z annotated_recs_d.
+Require ops_for_a ops_for_b ops_for_s ops_for_u ops_for_v.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/theories/arithmetics.v
+++ b/theories/arithmetics.v
@@ -134,7 +134,7 @@ Proof.
 elim: n => [|n ihn]; first by rewrite iter_lcmn0.
 by rewrite /iter_lcmn (@big_cat_nat _ _ _ n.+1) //= lcmn_gt0 ihn big_nat1.
 Qed.
-Hint Resolve iter_lcmn_gt0.
+#[export] Hint Resolve iter_lcmn_gt0 : core.
 
 Fact iter_lcmn_leq_div (n m : nat) : (n <= m)%N -> l n %| l m.
 Proof.

--- a/theories/b_over_a_props.v
+++ b/theories/b_over_a_props.v
@@ -1,16 +1,8 @@
-Require Import ZArith.
+Require Import BinInt.
 From mathcomp Require Import all_ssreflect all_algebra.
-
-Require Import extra_mathcomp.
-
-Require Import field_tactics lia_tactics shift.
-Require Import seq_defs.
-
-Require Import algo_closures reduce_order initial_conds.
-
+Require Import extra_mathcomp field_tactics lia_tactics shift.
 Require annotated_recs_c.
-
-Require Import a_props.
+Require Import seq_defs initial_conds algo_closures reduce_order a_props.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -19,7 +11,6 @@ Unset Printing Implicit Defensive.
 Import Order.TTheory GRing.Theory Num.Theory.
 
 Local Open Scope ring_scope.
-
 
 (**** We introduce and study the casoratian of a and b ****)
 

--- a/theories/b_props.v
+++ b/theories/b_props.v
@@ -1,11 +1,6 @@
 From mathcomp Require Import all_ssreflect all_algebra.
-
-Require Import extra_mathcomp.
-
-Require Import binomialz bigopz lia_tactics field_tactics.
-Require Import harmonic_numbers seq_defs.
-
-Require Import arithmetics a_props.
+Require Import field_tactics lia_tactics binomialz bigopz.
+Require Import arithmetics seq_defs a_props.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/theories/bigopz.v
+++ b/theories/bigopz.v
@@ -1,5 +1,4 @@
 From mathcomp Require Import all_ssreflect all_algebra.
-
 Require Import extra_mathcomp.
 (* Infrastructure for iterated operators indexed by ints. *)
 
@@ -220,10 +219,10 @@ case: m => m; case: n => n // hmn.
 - case: m hmn => [_ | m]; rewrite NegzE.
      by rewrite addNr big_map -NegzE /index_iotaz /= big_cons big_map.
   rewrite addrC subzSS add0r -!NegzE /index_iotaz -(addn1 m.+1).
-  by rewrite /index_iota subn0 iota_add map_cat rev_cat add0n /= big_cons.
+  by rewrite /index_iota subn0 iotaD map_cat rev_cat add0n /= big_cons.
 - case: m hmn => [ | m] //; rewrite !NegzE ltr_opp2 ltz_nat => hmn.
   rewrite addrC subzSS add0r -!NegzE /index_iotaz /index_iota subSn //.
-  by rewrite -[(_ - _).+1]addn1 iota_add rev_cat map_cat subnKC // big_cons.
+  by rewrite -[(_ - _).+1]addn1 iotaD rev_cat map_cat subnKC // big_cons.
 Qed.
 
 Lemma big_ltz m n F :

--- a/theories/binomialz.v
+++ b/theories/binomialz.v
@@ -48,7 +48,7 @@ Proof. by case: n => n. Qed.
 Fact binz_neg (n m : int) : m <= -1 -> binomialz n m = 0.
 Proof. by case: m => m //= _; case: n => n; case: m. Qed.
 
-Fact bin0z (m : int) : m >= 1 -> binomialz 0 m = 0.
+Fact bin0z (m : int) : 1 <= m -> binomialz 0 m = 0.
 Proof. by case: m => [ | m] // [ | m]. Qed.
 
 Fact bin_posz_posz (n m : nat) :
@@ -66,7 +66,7 @@ Fact bin_1N_posz (m : nat) :
 Proof. by []. Qed.
 
 (* Now more relations, combining inductions with the previous rules. *)
-Lemma bin_1N (m : int) : m >= 0 -> binomialz (Negz 0) m = (- 1) ^ m.
+Lemma bin_1N (m : int) : 0 <= m -> binomialz (Negz 0) m = (- 1) ^ m.
 Proof.
 case: m => m // _.
 by elim: m => [ | m ihm] //; rewrite bin_1N_posz ihm exprSz mulN1r.
@@ -231,18 +231,17 @@ Lemma binSz (n k : int): (k != n + 1) ->
 Proof.
 move=> hkn; case: (altP (k =P 0)) hkn => [-> | hk0] hkn.
   by rewrite !binz0 subr0 divff // -[1]/(1%:Q) -intrD intr_eq0 eq_sym.
-have hk : k = (k - 1) + 1 by rewrite -addrA subrr addr0.
+have hk : k = k - 1 + 1 by rewrite -addrA subrr addr0.
 rewrite hk binzSS; last by rewrite -hk.
 rewrite binzS; last by rewrite -hk.
 rewrite !rmorphD !rmorphN /=; rat_field.
 move: hk0 hkn hk; goal_to_lia; intlia.
 Qed.
 
-Lemma binz_gt0 (n k : int) :
-  n >= 0 -> k >= 0 -> n >= k -> binomialz n k > 0.
+Lemma binz_gt0 (n k : int) : 0 <= k -> k <= n -> 0 < binomialz n k.
 Proof.
-case: n => // n; case: k => // k _ _ lekn.
-by rewrite binz_nat_nat -[0]/(intr 0) ltr_int ltz_nat bin_gt0.
+case: n k => [] n [] k //= _ lekn.
+by rewrite binz_nat_nat -[0]/(intr 0) ltr_nat bin_gt0.
 Qed.
 
 (* Below, older results, possibly needing revision. *)

--- a/theories/c_props.v
+++ b/theories/c_props.v
@@ -1,7 +1,5 @@
 From mathcomp Require Import all_ssreflect all_algebra.
-
-Require Import binomialz lia_tactics.
-Require Import seq_defs.
+Require Import lia_tactics binomialz seq_defs.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/theories/extra_cauchyreals.v
+++ b/theories/extra_cauchyreals.v
@@ -1,7 +1,5 @@
 From mathcomp Require Import all_ssreflect all_algebra.
-
 From mathcomp Require Import bigenough cauchyreals.
-
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/theories/extra_mathcomp.v
+++ b/theories/extra_mathcomp.v
@@ -1,5 +1,4 @@
 From mathcomp Require Import all_ssreflect all_algebra all_field.
-
 From mathcomp Require Import bigenough.
 
 Set Implicit Arguments.

--- a/theories/hanson.v
+++ b/theories/hanson.v
@@ -1,20 +1,11 @@
 Require Import ZArith.
 From mathcomp Require Import all_ssreflect all_algebra all_field.
-
-Require Import arithmetics multinomial floor posnum binomialz.
+Require Import extra_mathcomp field_tactics lia_tactics binomialz floor.
+Require Import arithmetics posnum hanson_elem_arith hanson_elem_analysis.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
-
-Require Import field_tactics.
-Require Import bigopz.
-Require Import lia_tactics.
-Require Import shift.
-Require Import extra_mathcomp.
-
-Require Import hanson_elem_arith.
-Require Import hanson_elem_analysis.
 
 Import Order.TTheory GRing.Theory Num.Theory.
 
@@ -172,14 +163,14 @@ Implicit Types i : nat.
 Definition a' i : algC := exp_quo (a i)%:Q 1%N (a i).
 
 Lemma a'_gt0 i : 0 < a' i. Proof. by rewrite rootC_gt0 ?CratrE ?ltr0n. Qed.
-Hint Resolve a'_gt0.
+Hint Resolve a'_gt0 : core.
 
 Lemma a'_ge0 i : 0 <= a' i. Proof. exact: ltW. Qed.
-Hint Resolve a'_ge0.
+Hint Resolve a'_ge0 : core.
 
 Lemma a'_gt1 i : 1 < a' i.
 Proof. by rewrite exprn_egte1 // rootC_gt1 ?ltr1q ?ltr1n. Qed.
-Hint Resolve a'_gt1.
+Hint Resolve a'_gt1 : core.
 
 Lemma a'_S i (Hi : (2 <= i)%N) : a' i.+1 <= sqrtC (a' i).
 Proof.
@@ -242,8 +233,8 @@ suff -> : exp_quo (a k)%:Q (2 ^ l.+2 - 2) (2 ^ l.+1 * a k) =
   rewrite mulrA.
   apply: ler_pmul; rewrite ?a'_bound // ?rootC_ge0 ?CratrE ?a_pos ?ler0n //.
   by rewrite prodr_ge0 // => i _ ; exact: a'_ge0.
-rewrite -prod_root ?CratrE ?expn_gt0 ?a_pos ?ler0n // .
-have -> : (2 ^ l * a k).-root (a k)%:R = exp_quo (a k)%:R 1%N (2 ^ l * a k).
+rewrite -prod_root ?CratrE ?expn_gt0 ?a_pos ?ler0n //.
+have -> : (2 ^ l * a k).-root (a k)%:R = exp_quo (a k)%:R 1 (2 ^ l * a k).
   by rewrite /exp_quo expr1 2!CratrE.
 rewrite -exp_quo_plus ?ler0n // ?muln_gt0 ?a_pos ?expn_gt0 //.
 rewrite [(2 ^ l.+1)%N]expnS -mulnA -mulnDl -subnA ?leq_pmulr ?expn_gt0 //=.
@@ -286,17 +277,17 @@ Definition a'4_ub : rat := rat_of_Z 201 / rat_of_Z 200.
 End A'.
 
 (* Reported to survive end of section *)
-Hint Resolve a'_gt0.
-Hint Resolve a'_ge0.
-Hint Resolve a'_gt1.
-Hint Resolve w_seq_ge0.
+#[export] Hint Resolve a'_gt0 : core.
+#[export] Hint Resolve a'_ge0 : core.
+#[export] Hint Resolve a'_gt1 : core.
+#[export] Hint Resolve w_seq_ge0 : core.
 
 Module Computations.
 
 (* Can't be moved before *)
 (* Import ZArith. *)
 
-Hint Resolve rat_of_Z_Zpos.
+#[local] Hint Resolve rat_of_Z_Zpos : core.
 
 (* Missing from rat_of_Zpos *)
 Lemma rat_of_Z_ZposW z : 0 <= rat_of_Z (Zpos z).
@@ -316,7 +307,7 @@ rewrite Zpower_nat_succ_r; case: rat_morph_Z => _ _ _ _ -> _ _.
 by rewrite ihn -[RHS]exprnP exprS exprnP.
 Qed.
 
-Hint Resolve rat_of_Z_ZposW.
+#[local] Hint Resolve rat_of_Z_ZposW : core.
 
 Definition w : rat := a'0_ub * a'1_ub * a'2_ub * a'3_ub * a'4_ub ^ 2.
 
@@ -510,15 +501,15 @@ End Computations.
 
 Import Computations.
 
-Hint Resolve w_gt0.
-Hint Resolve w_ge0.
+#[export] Hint Resolve w_gt0 : core.
+#[export] Hint Resolve w_ge0 : core.
 
 (* change name to make it not seem general *)
 Lemma prod_is_exp_sum (n k : nat) (tenn := (10 * n)%N%:Q) :
   \prod_(i < k.+1) exp_quo tenn (a i).-1 (a i) =
   tenn%:C ^+ k * exp_quo tenn 1 (a k.+1 - 1).
 Proof.
-elim: k => [|k ihk]; first by rewrite expr0 big_ord_recr big_ord0 /=.
+elim: k => [|k ihk]; first by rewrite expr0 big_ord_recr big_ord0.
 have pos_tenn : 0 <= tenn by rewrite /tenn ler0n.
 have h l : tenn%:C ^+ l = exp_quo tenn l 1 by rewrite -exp_quo_r_nat -!CratrE.
 rewrite big_ord_recr ihk /= !h !subn1 -!exp_quo_plus ?ltnS ?muln_gt0 ?a_pos //=.
@@ -531,8 +522,8 @@ Proof. by rewrite ltr0n. Qed.
 Lemma aR_ge0 i : 0 <= (a i)%:~R :> algC.
 Proof. by rewrite ler0n. Qed.
 
-Hint Resolve aR_gt0.
-Hint Resolve aR_ge0.
+#[export] Hint Resolve aR_gt0 : core.
+#[export] Hint Resolve aR_ge0 : core.
 
 Section PreliminaryRemarksTheorem2.
 
@@ -587,7 +578,7 @@ rewrite -mulrA; set tw := (X in _ < _ * X).
 have tw_pos : 0 <= tw by apply: mulr_ge0.
 have tenn_to_pos : 0 <= ((10 * n)%N%:Q ^+ k)%:C.
   by rewrite ler0q exprn_ge0 ?ler0n.
-suff step2 : cn < ((10 * n)%N%:Q ^+ k)%:C * t10n_to 1%N (a k.+1).-1%N * tw.
+suff step2 : cn < ((10 * n)%N%:Q ^+ k)%:C * t10n_to 1%N (a k.+1).-1 * tw.
   apply: lt_le_trans step2 _; rewrite exp_quo_r_nat.
   have ->: t10n_to (2 * k.+1 - 1)%N 2 = t10n_to k 1%N * t10n_to 1%N 2.
     rewrite -exp_quo_plus ?ler0n //; apply:exp_quo_equiv => //.
@@ -669,11 +660,11 @@ case: k Hank => [| k] //; case: k => [| k Hank]; last exact: k_bound.
 by rewrite addn2.
 Qed.
 
-Theorem t3_nat : exists (K : nat),
+Theorem t3_nat : exists K : nat,
     (0 < K)%N /\ forall n : nat, (iter_lcmn n <= K * 3 ^ n)%N.
 Proof.
 pose cond n k := (a k <= n < a k.+1)%N.
-suff [K [Kpos KP]] : exists (K : nat),
+suff [K [Kpos KP]] : exists K : nat,
     (0 < K)%N /\ (forall n k, cond n k -> C n k.+1 <= K * 3 ^ n)%N.
   exists K; split => // n; case: (leqP n 1)=> hn; last first.
     apply: leq_trans (KP _ (f_k n) _); first exact: lcm_leq_Cnk.
@@ -698,7 +689,7 @@ pose eps : rat := locked (w / 3%:R).
 have epsE : eps = w / 3%:R by rewrite /eps -lock.
 have lt0eps1 : 0 < eps < 1.
   by rewrite epsE ltr_pdivl_mulr // mul0r ltr_pdivr_mulr // mul1r w_lt3 w_gt0.
-pose u n k eps := (m * n%:R) ^ k.+1 * eps ^ n.+1 : rat.
+pose u n k eps : rat := (m * n%:R) ^ k.+1 * eps ^ n.+1.
 suff hloglog : exists (K : rat), (0 < K) /\ (forall n k, cond n k -> u n k eps < K).
   have [K [lt0K KP]] := hloglog.
   exists (K * 3%:Q); split; first by exact: mulr_gt0.
@@ -718,11 +709,11 @@ suff {u} [K [Kpos KP]] : exists K : rat, 0 < K /\ forall n, v n < K.
   apply: exp_incr_expp; first by apply: mulr_ege1=> //; rewrite ler1n.
   by rewrite ltnS -addn2.
 have h1 n : ((trunc_log 2 n).+1 <= 2 ^ (loglog n).+1)%N by exact: trunc_log_ltn.
-have {}h1 n : (n < 2 ^ (2 ^ (loglog n).+1))%N.
+have {}h1 n : (n < 2 ^ 2 ^ (loglog n).+1)%N.
   have h : (n < 2 ^ (trunc_log 2 n).+1)%N by exact: trunc_log_ltn.
   have {}h : (2 ^ (trunc_log 2 n).+1 <= 2 ^ (2 ^ (loglog n).+1))%N by rewrite leq_exp2l.
   exact/leq_trans/h/trunc_log_ltn.
-have h2 n : (1 < n)%N -> (2 ^ (2 ^ (loglog n)) <= n)%N.
+have h2 n : (1 < n)%N -> (2 ^ 2 ^ loglog n <= n)%N.
   move=> lt1n.
   have h: (2 ^ trunc_log 2 n <= n)%N by apply/trunc_logP/ltnW.
   apply: leq_trans h; rewrite leq_exp2l; last by [].
@@ -774,7 +765,7 @@ have le_0_t n : 0 <= t n by exact: ltW.
 suff {x h1 h2 u} [K [Kpos KP]] : exists K : rat, 0 < K /\ forall n, t n < K.
   by exists K; split => // n; apply: le_lt_trans (KP (loglog n)).
 pose l n := (alpha n)%:R ^ 4 * eps ^ ((alpha n)%:Z ^ 2 - 2%:Z * (alpha n)%:Z).
-have alphaS n : (alpha n.+1 = (alpha n) ^ 2)%N.
+have alphaS n : (alpha n.+1 = alpha n ^ 2)%N.
   by rewrite /alpha expnS mulnC expnM.
 have le_0_alpham2 k : 0 <= (alpha k)%:Z - 2%:Z.
   rewrite /alpha; apply: (@le_trans _ _ ((2 ^ 2 ^ 0)%:Z - 2%:Z)) => //.
@@ -882,8 +873,8 @@ have lt_ln_1 (n : nat) : (3 <= n)%N -> l n <= 1.
   rewrite leq_eqVlt => /predU1P [<- | {}/ihn ihn]; first by rewrite [l]lock. (* unlock does not work... *)
   suff h : l n.+1 <= (l n) ^ 2 by apply: le_trans h _; apply: mulr_ile1.
   rewrite /l expfzMl exprz_exp; apply: ler_pmul.
-  - apply: exprz_ge0; exact: ler0n.
-  - apply: exprz_ge0; exact: ltW.
+  - exact/exprz_ge0/ler0n.
+  - exact/exprz_ge0/ltW.
   - by rewrite alphaS natrX exprnP exprz_exp.
   rewrite exprz_exp; apply: ler_wpiexpz2l.
   - exact: ltW.

--- a/theories/hanson_elem_analysis.v
+++ b/theories/hanson_elem_analysis.v
@@ -1,14 +1,9 @@
 From mathcomp Require Import all_ssreflect all_algebra all_field.
-
-Require Import floor posnum.
+Require Import extra_mathcomp posnum hanson_elem_arith.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
-
-Require Import extra_mathcomp.
-
-Require Import hanson_elem_arith.
 
 Import Order.TTheory GRing.Theory Num.Theory.
 

--- a/theories/hanson_elem_arith.v
+++ b/theories/hanson_elem_arith.v
@@ -1,15 +1,10 @@
 From mathcomp Require Import all_ssreflect all_algebra.
-
-Require Import arithmetics multinomial floor.
-
+Require Import extra_mathcomp field_tactics lia_tactics.
+Require Import floor arithmetics multinomial.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
-
-Require Import field_tactics.
-Require Import lia_tactics.
-Require Import extra_mathcomp.
 
 Import Order.TTheory GRing.Theory Num.Theory.
 
@@ -39,15 +34,15 @@ Proof. by []. Qed.
 
 Lemma a_pos n : 0 < a n.
 Proof. by case: n. Qed.
-Hint Resolve a_pos.
+Hint Resolve a_pos : core.
 
 Lemma a_gt1 n : 1 < a n.
 Proof. by elim: n => // n ihn; rewrite aS ltnS muln_gt0; case: (a n) ihn. Qed.
-Hint Resolve a_gt1.
+Hint Resolve a_gt1 : core.
 
 Lemma pa_gt0 n : 0 < (a n).-1.
 Proof. by rewrite -ltnS prednK. Qed.
-Hint Resolve pa_gt0.
+Hint Resolve pa_gt0 : core.
 
 Lemma a_grows1 n : a n < a n.+1.
 Proof. by rewrite aS ltnS leq_pmulr. Qed.
@@ -66,11 +61,11 @@ Qed.
 
 Lemma aS_gt2 k : 2 < a k.+1.
 Proof. by suff H1 : (2 < a 1) by apply: leq_trans H1 (a_grows _). Qed.
-Hint Resolve aS_gt2.
+Hint Resolve aS_gt2 : core.
 
 Lemma aSpred_gt1 k : (1 < (a k.+1).-1)%N.
 Proof. by rewrite -subn1 ltn_subRL addn1. Qed.
-Hint Resolve aSpred_gt1.
+Hint Resolve aSpred_gt1 : core.
 
 Lemma a_rec (n : nat) : a n = \prod_(0 <= i < n) a i + 1.
 Proof.
@@ -91,16 +86,16 @@ Definition a_rat (n : nat) : rat := (a n)%:Q.
 (* Unfortunately, we need to duplicate the trivialities, in order to make them
  available to the copies of a in rational numbers. *)
 Lemma a_rat_gt1 (n : nat) : 1 < (a n)%:Q. Proof. by rewrite ltr1n. Qed.
-Hint Resolve a_rat_gt1.
+Hint Resolve a_rat_gt1 : core.
 
 Lemma a_rat_sub1_gt0 (n : nat) : 0 < (a n)%:Q - 1. by rewrite subr_gt0. Qed.
-Hint Resolve a_rat_sub1_gt0.
+Hint Resolve a_rat_sub1_gt0 : core.
 
 Lemma a_rat_pos (n : nat) : 0 < (a n)%:Q. Proof. by rewrite ltr0n. Qed.
-Hint Resolve a_rat_pos.
+Hint Resolve a_rat_pos : core.
 
 Lemma a_rat_ge0 (n : nat) : 0 <= (a n)%:Q. Proof. by rewrite ler0n. Qed.
-Hint Resolve a_rat_ge0.
+Hint Resolve a_rat_ge0 : core.
 
 Lemma a_rat_rec1 (n : nat) : (a (n.+1))%:Q = (a n)%:Q * ((a n)%:Q - 1) + 1.
 Proof.
@@ -116,16 +111,16 @@ Qed.
 End DefinitionOfA.
 
 (* We lack a "Global" for Hint Resolve. *)
-Hint Resolve a_pos.
-Hint Resolve a_gt1.
-Hint Resolve pa_gt0.
-Hint Resolve aS_gt2.
-Hint Resolve aSpred_gt1.
+#[export] Hint Resolve a_pos : core.
+#[export] Hint Resolve a_gt1 : core.
+#[export] Hint Resolve pa_gt0 : core.
+#[export] Hint Resolve aS_gt2 : core.
+#[export] Hint Resolve aSpred_gt1 : core.
 
-Hint Resolve a_rat_gt1.
-Hint Resolve a_rat_sub1_gt0.
-Hint Resolve a_rat_pos.
-Hint Resolve a_rat_ge0.
+#[export] Hint Resolve a_rat_gt1 : core.
+#[export] Hint Resolve a_rat_sub1_gt0 : core.
+#[export] Hint Resolve a_rat_pos : core.
+#[export] Hint Resolve a_rat_ge0 : core.
 
 Section BoundsOnA.
 
@@ -280,7 +275,7 @@ Definition C n k : nat := 'C[C_row n k] * (n - \sum_(0 <= i < k) n %/ a i)`!.
 
 Lemma C_pos n k : 0 < C n k.
 Proof. by rewrite muln_gt0 multi_gt0 fact_gt0. Qed.
-Hint Resolve C_pos.
+Hint Resolve C_pos : core.
 
 Lemma nth_C_row n k i :
   nth 0 (C_row n k) i =

--- a/theories/harmonic_numbers.v
+++ b/theories/harmonic_numbers.v
@@ -1,8 +1,6 @@
 (* A stub library on generalized harmonic numbers. *)
 From mathcomp Require Import all_ssreflect all_algebra.
-
-Require Import shift bigopz.
-Require Import field_tactics.
+Require Import field_tactics shift bigopz.
 
 Import Order.TTheory GRing.Theory Num.Theory.
 

--- a/theories/initial_conds.v
+++ b/theories/initial_conds.v
@@ -1,8 +1,6 @@
+Require Import BinInt.
 From mathcomp Require Import all_ssreflect all_algebra.
-Require Import binomialz.
-Require Import field_tactics.
-Require Import seq_defs.
-
+Require Import field_tactics binomialz seq_defs.
 Require harmonic_numbers.
 
 Local Open Scope ring_scope.
@@ -57,8 +55,6 @@ Ltac solve_b_evaluation :=
 
 (* Evaluations for the sequence b. With our definition we have:
         b_n = 0, 6, 351/4, 62531/36, ... *)
-
-Import ZArith.
 
 Lemma b0_eq : b 0 = 0.
 Proof. solve_b_evaluation. Qed.

--- a/theories/multinomial.v
+++ b/theories/multinomial.v
@@ -1,5 +1,4 @@
 From mathcomp Require Import all_ssreflect all_algebra.
-
 Require Import extra_mathcomp.
 
 Import Order.TTheory GRing.Theory Num.Theory.

--- a/theories/posnum.v
+++ b/theories/posnum.v
@@ -157,34 +157,3 @@ Qed.
 #[export] Hint Resolve posnum_neq0 : core.
 Notation "[gt0 'of' x ]" := (posnum_gt0_def (Phantom algC x))
  (format "[gt0 'of'  x ]").
-
-
-Variable f : algC -> algC.
-Hypothesis H : forall x, f x > 0.
-
-Lemma f_gt0 (x : {posnum algC}) :  0 < f x%:num.
-Proof. by rewrite H. Qed.
-Canonical f_posnum (x : {posnum algC}) := PosNum (f_gt0 x).
-
-Lemma SnC_gt0 (n : nat) : 0 < n.+1%:R :> algC.
-Proof. by rewrite ltr0n. Qed.
-Canonical SnC_posnum n := PosNum (SnC_gt0 n).
-
-Lemma Sz_gt0 (n : nat) : 0 < n.+1%:~R :> algC.
-Proof. by rewrite ltr0n. Qed.
-Canonical Sz_posnum n := PosNum (@Sz_gt0 n).
-
-(* Goal forall n (Hn : (n > 0)%nat), True. *)
-(* move => n Hn. *)
-(* Check (n%:R %:pos). *)
-
-(* Require Import rat. *)
-
-(* Lemma foo : forall (n : nat) (Hn : (n > 0)%nat), (f ((n %:R)) * 2%:R : algC) > 0. *)
-(* Proof. *)
-(* move => n Hn. *)
-(* Check (PosNum (n_gt0 Hn)). *)
-(* Check (n%:R %:pos). *)
-(* Check ([gt0 of (f (n%:R : algC) * (2 : algC))]). *)
-(* (* move => H1. *) *)
-(* (* Check ([gt0 of (f (3 %:R) * 2 : algC)]). *) *)

--- a/theories/posnum.v
+++ b/theories/posnum.v
@@ -42,7 +42,7 @@ Local Open Scope ring_scope.
 (* infer class to help typeclass inference on the fly *)
 Class infer (P : Prop) := Infer : P.
 (* Hint Mode infer ! : typeclass_instances. *)
-Hint Extern 0 (infer _) => (exact) : typeclass_instances.
+#[export] Hint Extern 0 (infer _) => (exact) : typeclass_instances.
 Lemma inferP (P : Prop) : P -> infer P. Proof. by []. Qed.
 
 Lemma splitr (R : numFieldType) (x : R) : x = x / 2%:R + x / 2%:R.
@@ -52,8 +52,8 @@ Record posnum_def (R : numDomainType) := PosNumDef {
   num_of_pos :> R;
   posnum_gt0 : num_of_pos > 0
 }.
-Hint Resolve posnum_gt0.
-Hint Extern 0 ((0 < _)%R = true) => exact: posnum_gt0 : core.
+#[export] Hint Resolve posnum_gt0 : core.
+#[export] Hint Extern 0 ((0 < _)%R = true) => exact: posnum_gt0 : core.
 Definition posnum_of (R : numDomainType) (phR : phant R) := posnum_def R.
 Identity Coercion posnum_of_id : posnum_of >-> posnum_def.
 Notation "'{posnum' R }" := (posnum_of (@Phant R))
@@ -119,8 +119,8 @@ Lemma one_pos_gt0 : 0 < 1 :> R. Proof. by rewrite ltr01. Qed.
 Canonical oner_posnum := PosNum one_pos_gt0.
 
 End PosNum.
-Hint Extern 0 ((0 <= _)%R = true) => exact: posnum_ge0 : core.
-Hint Extern 0 ((_ != 0)%R = true) => exact: posnum_neq0 : core.
+#[export] Hint Extern 0 ((0 <= _)%R = true) => exact: posnum_ge0 : core.
+#[export] Hint Extern 0 ((_ != 0)%R = true) => exact: posnum_neq0 : core.
 
 Section PosNumReal.
 Context {R : realDomainType}.
@@ -141,7 +141,7 @@ Lemma sqrt_pos_gt0 (R : rcfType) (x : {posnum R}) : 0 < Num.sqrt x%:num.
 Proof. by rewrite sqrtr_gt0. Qed.
 Canonical sqrt_posnum (R : rcfType) (x : {posnum R}) := PosNum (sqrt_pos_gt0 x).
 
-CoInductive posnum_spec (R : numDomainType) (x : R) :
+Variant posnum_spec (R : numDomainType) (x : R) :
   R -> bool -> bool -> bool -> Type :=
 | IsPosnum (p : {posnum R}) : posnum_spec x (p : R) false true true.
 
@@ -152,9 +152,9 @@ move=> x_gt0; case: real_ltgt0P (x_gt0) => []; rewrite ?gtr0_real // => _ _.
 by rewrite -[x]/(PosNum x_gt0)%:num; constructor.
 Qed.
 
-Hint Resolve posnum_gt0.
-Hint Resolve posnum_ge0.
-Hint Resolve posnum_neq0.
+#[export] Hint Resolve posnum_gt0 : core.
+#[export] Hint Resolve posnum_ge0 : core.
+#[export] Hint Resolve posnum_neq0 : core.
 Notation "[gt0 'of' x ]" := (posnum_gt0_def (Phantom algC x))
  (format "[gt0 'of'  x ]").
 

--- a/theories/punk.v
+++ b/theories/punk.v
@@ -1,6 +1,5 @@
 From mathcomp Require Import all_ssreflect all_algebra.
-Require Import bigopz.
-Require Import shift.
+Require Import shift bigopz.
 
 Import Order.TTheory GRing.Theory Num.Theory.
 
@@ -12,7 +11,7 @@ Local Open Scope ring_scope.
 
 
 (* Compare with (f ^~ y). *)
-Let pfun2 Tx Ty Tz T (f : Tx -> Ty -> Tz -> T) z := (fun x y => f x y z).
+Local Definition pfun2 Tx Ty Tz T (f : Tx -> Ty -> Tz -> T) z x y := f x y z.
 
 
 Section CreativeTelescopingMasterLemma.

--- a/theories/rat_of_Z.v
+++ b/theories/rat_of_Z.v
@@ -1,5 +1,4 @@
 Require Import ZArith.
-
 From mathcomp Require Import all_ssreflect all_algebra.
 
 Set Implicit Arguments.
@@ -9,7 +8,6 @@ Unset Printing Implicit Defensive.
 Import GRing.Theory Num.Theory.
 
 Local Open Scope ring_scope.
-
 
 (*  We define an *opaque* cast:                                                *)
 (*     rat_of_Z : Z -> rat                                                     *)

--- a/theories/rat_pos.v
+++ b/theories/rat_pos.v
@@ -3,9 +3,8 @@
    them to concrete values that will be used in the rest of the
    formalization. *)
 
-Require Import ZArith.
+Require Import BinInt.
 From mathcomp Require Import all_ssreflect all_algebra.
-
 Require Import field_tactics lia_tactics.
 
 Import Order.TTheory GRing.Theory Num.Theory.

--- a/theories/reduce_order.v
+++ b/theories/reduce_order.v
@@ -1,16 +1,7 @@
-Require Import ZArith.
-
+Require Import BinInt.
 From mathcomp Require Import all_ssreflect all_algebra.
-Require Import binomialz bigopz.
-Require Import field_tactics lia_tactics shift.
-Require Import extra_mathcomp.
-Require Import seq_defs.
-
-Require harmonic_numbers.
-Require (* rat_pos *) algo_closures initial_conds.
-
-Require annotated_recs_c.
-Require annotated_recs_v.
+Require Import field_tactics lia_tactics binomialz shift seq_defs.
+Require annotated_recs_c annotated_recs_v algo_closures initial_conds.
 
 Import Order.TTheory GRing.Theory Num.Theory.
 
@@ -71,7 +62,7 @@ Proof.  by rewrite /= initial_conds.b0_eq.  Qed.
 Lemma b'1_eq : b' 1 = 6%:Q.
 Proof.  by rewrite /= initial_conds.b1_eq.  Qed.
 
-Lemma b'2_eq : b' (2 : int) = rat_of_Z 351 / rat_of_Z 4.
+Lemma b'2_eq : b' 2%N = rat_of_Z 351 / rat_of_Z 4.
 Proof.
 rewrite -[Posz 2]/(int.shift 2 0) b'_Sn2_rew // b'0_eq b'1_eq.
 rewrite /annotated_recs_c.P_cf0 /annotated_recs_c.P_cf1 /annotated_recs_c.P_cf2.
@@ -79,7 +70,7 @@ by apply/eqP; rewrite rat_of_ZEdef; vm_compute.
 (* Faster than: rat_field; goal_to_lia; intlia. *)
 Qed.
 
-Lemma b'3_eq : b' (3 : int) = rat_of_Z 62531 / rat_of_Z 36.
+Lemma b'3_eq : b' 3%N = rat_of_Z 62531 / rat_of_Z 36.
 Proof.
 rewrite -[Posz 3]/(int.shift 2 1) b'_Sn2_rew // b'1_eq b'2_eq.
 rewrite /annotated_recs_c.P_cf0 /annotated_recs_c.P_cf1 /annotated_recs_c.P_cf2.
@@ -89,7 +80,7 @@ do 2! (split; first by move/eqP; rewrite rat_of_Z_eq0).
 by move/eqP; rewrite rat_of_Z_eq0.
 Qed.
 
-Lemma b'4_eq : b' (4 : int) = rat_of_Z 11424695 / rat_of_Z 288.
+Lemma b'4_eq : b' 4%N = rat_of_Z 11424695 / rat_of_Z 288.
 Proof.
 rewrite -[Posz 4]/(int.shift 2 2) b'_Sn2_rew // b'2_eq b'3_eq.
 rewrite /annotated_recs_c.P_cf0 /annotated_recs_c.P_cf1 /annotated_recs_c.P_cf2.
@@ -121,8 +112,8 @@ Ltac affine_poly_intlia :=
   rewrite ?intr_eq0 ?ltr0z ?ler0z; intlia.
 
 Lemma Sn4_flat_to_Sn4_rew (w : int -> rat) :
-  (forall n : int, n >= (2 : int) -> annotated_recs_v.P_horner w n = 0) ->
-  (forall n : int, n >= (2 : int) ->
+  (forall n : int, 2 <= n :> int -> annotated_recs_v.P_horner w n = 0) ->
+  (forall n : int, 2 <= n :> int ->
     w (int.shift 4 n) =
       - (annotated_recs_v.P_cf0 n * w n + 
          annotated_recs_v.P_cf1 n * w (int.shift 1 n) +
@@ -183,7 +174,7 @@ Proof.  by rewrite /int.shift intS addrC.  Qed.
 (* that we shift the verification of the initial conditions to the first *)
 (* values from which we are able to establish the recurrence by closures. *)
 Lemma b'_eq_b_reduction (k : int) :
-k >= (2 : int) ->
+  2 <= k :> int ->
   b' k = b k -> b' (k + 1) = b (k + 1) ->
   b' (k + 2) = b (k + 2) -> b' (k + 3) = b (k + 3) ->
   forall (n : int), n >= k -> b' n = b n.
@@ -195,7 +186,7 @@ pose p : int := n - k; simpl in p.
 have -> : n = p + k by rewrite /p addrNK.
 clearbody p; clear n.
 rewrite ler_addr.
-suff gen (n : int) : (0 : int) <= n -> n <= p -> b' (n + k) = b (n + k).
+suff gen (n : int) : 0 <= n -> n <= p -> b' (n + k) = b (n + k).
   by move=> p_pos; apply: (gen _ p_pos).
 move: n.
 elim/int_rect: p => [p h0p hp0 | p ihp n le0n hnp | p _ n hn hp]; last 1 first.
@@ -219,10 +210,9 @@ have hmp : m + 3 <= p by move: hnp; rewrite -addn1 PoszD hm; clear; intlia.
 rewrite hm; clearbody m; clear le0n hnp hn0 hn1 hn2 hn3 hm n.
 have -> : m + 4 + k = int.shift 4 (m + k).
   by rewrite int.shift2Z addrAC.
-have b'_Sn4_from2 (n : int) : (2 : int) <= n -> 
-                               annotated_recs_v.P_horner b' n = 0.
+have b'_Sn4_from2 n : 2 <= n :> int -> annotated_recs_v.P_horner b' n = 0.
   by move=> hn; apply: b'_Sn4; apply: le_trans hn.
-have hmk2 : (2 : int) <= m + k by move: kpos le0m; clear; intlia.
+have hmk2 : 2 <= m + k :> int by move: kpos le0m; clear; intlia.
 rewrite (Sn4_flat_to_Sn4_rew b'_Sn4_from2 hmk2); clear b'_Sn4_from2.
 rewrite (Sn4_flat_to_Sn4_rew algo_closures.b_Sn4 hmk2); clear hmk2.
 rewrite !int.shift2Z ![m + k + _]addrAC.

--- a/theories/rho_computations.v
+++ b/theories/rho_computations.v
@@ -1,12 +1,10 @@
 Require Import BinInt.
-
 From mathcomp Require Import all_ssreflect all_algebra.
 Require Import rat_of_Z.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
-
 
 From CoqEAL Require Import hrel param refinements.
 From CoqEAL Require Import pos binnat binint rational.
@@ -57,8 +55,7 @@ Qed.
 (* Generic programming of your functions : *)
 (* we abstract wrt Q and all the operations you use *)
 Section generic.
-Import Refinements.
-Import Op.
+Import Refinements.Op.
 
 (* In the future, many of these might come packaged together *)
 Context (AQ : Type).
@@ -113,8 +110,7 @@ Definition  h_iter :=
    style so that it is as "free" in the implementation as it is in
    theory. *)
 Section parametric.
-Import Refinements.
-Import Op.
+Import Refinements.Op.
 
 Context (AQ : Type).
 Context (zeroAQ : zero_of AQ) (addAQ : add_of AQ) (oppAQ : opp_of AQ) (subAQ : sub_of AQ).

--- a/theories/s_props.v
+++ b/theories/s_props.v
@@ -1,7 +1,5 @@
 From mathcomp Require Import all_ssreflect all_algebra.
-
-Require Import binomialz bigopz.
-Require Import seq_defs.
+Require Import binomialz bigopz seq_defs.
 
 Set Implicit Arguments.
 Unset Strict Implicit.

--- a/theories/seq_defs.v
+++ b/theories/seq_defs.v
@@ -5,7 +5,6 @@
    algorithmically getting a recurrence on b. *)
 
 From mathcomp Require Import all_ssreflect all_algebra.
-
 Require Import binomialz bigopz.
 Require harmonic_numbers.
 

--- a/theories/z3irrational.v
+++ b/theories/z3irrational.v
@@ -1,14 +1,8 @@
 From mathcomp Require Import all_ssreflect all_algebra.
-
 From mathcomp Require Import bigenough cauchyreals.
-
-Require Import bigopz extra_cauchyreals extra_mathcomp.
-Require Import field_tactics shift.
-
-Require Import seq_defs.
-Require Import arithmetics.
+Require Import extra_mathcomp extra_cauchyreals.
+Require Import field_tactics shift bigopz arithmetics seq_defs.
 Require Import c_props s_props z3seq_props a_props b_props b_over_a_props.
-
 Require hanson.
 
 Set Implicit Arguments.

--- a/theories/z3seq_props.v
+++ b/theories/z3seq_props.v
@@ -1,7 +1,5 @@
 From mathcomp Require Import all_ssreflect all_algebra.
-
-Require Import field_tactics lia_tactics bigopz.
-Require Import harmonic_numbers seq_defs.
+Require Import field_tactics lia_tactics bigopz harmonic_numbers seq_defs.
 
 Set Implicit Arguments.
 Unset Strict Implicit.


### PR DESCRIPTION
This PR contains some cleanup work, partly from #4 but independent from the use of Mczify and Algebra Tactics. As a result, it is no longer compatible with Coq 8.11. Since the Algebra Tactics package is not compatible with Coq 8.11 anyway, dropping the support for it seems fine.

Warnings treated in this PR are turned into errors so that they will not be reintroduced. See `_CoqProject` for details.

Also, Apery does not compile with MathComp dev anymore because of math-comp/math-comp#841. I will recover this compatibility in #4 rather than here.