### PR TITLE
More qualified import of `zify.ssrZ`

### DIFF
--- a/theories/rat_of_Z.v
+++ b/theories/rat_of_Z.v
@@ -1,6 +1,6 @@
 Require Import ZArith.
 From mathcomp Require Import all_ssreflect all_algebra.
-From mathcomp Require Export ssrZ.
+From mathcomp.zify Require Export ssrZ.
 Require Import tactics.
 
 Set Implicit Arguments.


### PR DESCRIPTION
Without a qualified import `coq-mathcomp-apery` is incompatible with `coq-mathcomp-word`. See also https://github.com/jasmin-lang/coqword/issues/15 and https://github.com/coq/opam-coq-archive/pull/2454