### PR TITLE
rm warning caused by lack of archimedean

### DIFF
--- a/theories/a_props.v
+++ b/theories/a_props.v
@@ -1,6 +1,6 @@
 Require Import BinInt.
 
-From mathcomp Require Import all_ssreflect ssralg ssrnum ssrint rat.
+From mathcomp Require Import all_ssreflect ssralg ssrnum ssrint rat archimedean.
 From mathcomp Require Import realalg.
 
 From CoqEAL Require Import hrel param refinements.

--- a/theories/b_props.v
+++ b/theories/b_props.v
@@ -1,4 +1,5 @@
 From mathcomp Require Import all_ssreflect ssralg ssrnum ssrint intdiv rat.
+From mathcomp Require Import archimedean.
 Require Import tactics binomialz bigopz arithmetics seq_defs a_props.
 
 Set Implicit Arguments.

--- a/theories/binomialz.v
+++ b/theories/binomialz.v
@@ -1,4 +1,4 @@
-From mathcomp Require Import all_ssreflect ssralg ssrnum ssrint.
+From mathcomp Require Import all_ssreflect ssralg ssrnum ssrint archimedean.
 Require Import tactics.
 
 Set Implicit Arguments.

--- a/theories/extra_mathcomp.v
+++ b/theories/extra_mathcomp.v
@@ -1,5 +1,5 @@
-From mathcomp Require Import all_ssreflect ssralg ssrnum ssrint rat all_field.
-From mathcomp Require Import bigenough.
+From mathcomp Require Import all_ssreflect ssralg ssrnum ssrint rat archimedean.
+From mathcomp Require Import all_field bigenough.
 
 Set Implicit Arguments.
 Unset Strict Implicit.


### PR DESCRIPTION
To avoid an error in MathComp's CI (see https://github.com/math-comp/math-comp/commit/0240d6c7c46015d333b12889b04acd179224d9d3)